### PR TITLE
Default delimiter to ',' when one is not found

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,10 @@ module.exports = function detectCSV(chunk, opts) {
   var delimiter = determineMost(lines[0], delimiters)
   var newline = determineMost(chunk, newlines)
   
-  if (!delimiter) return null
+  if (!delimiter) {
+    if (chunk.match(/[{}]/g)) return null
+    delimiter = ','
+  }
 
   return {
     delimiter: delimiter,

--- a/test.js
+++ b/test.js
@@ -38,6 +38,13 @@ test('detect newlines', function (t) {
   t.end()
 })
 
+test('detect single-column csv', function(t) {
+  var d
+  d = detect('single_column\rrow1\rrow2\rrow3\r') || {}
+  t.equals(d.delimiter, ',', 'delimiter is defaulted to ","')
+  t.equals(d.newline, '\r', 'newlines are detected correctly')
+  t.end()
+})
 
 //  should this considered be valid csv? {"a": 1, "b": 2, "c": 3}\n{"a": 1, "b": 2, "c": 3}
 // it's like ['{"a": 1', '"b": 2' ... ]


### PR DESCRIPTION
This allows for single-column CSV files to be detected.